### PR TITLE
Bugfix/PLUGIN-488

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.1.2</cdap.version>
+    <powermock.version>2.0.2</powermock.version>
   </properties>
 
   <repositories>
@@ -56,6 +57,12 @@
       <groupId>io.cdap.cdap</groupId>
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -123,8 +130,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.1.2-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.1.2-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/add/field/MultiFieldAdderConfig.java
+++ b/src/main/java/io/cdap/plugin/add/field/MultiFieldAdderConfig.java
@@ -39,18 +39,21 @@ public class MultiFieldAdderConfig extends PluginConfig {
 
   Map<String, String> getFieldValue() throws IllegalArgumentException {
     Map<String, String> values = new TreeMap<>();
-    if (containsMacro(FIELD_VALUE) || fieldValue == null || fieldValue.trim().isEmpty()) {
+    if (containsMacro(FIELD_VALUE)) {
+      fieldValue = getMacroFieldValue();
+    }
+    if (fieldValue == null || fieldValue.trim().isEmpty()) {
       return values;
     }
 
     String[] fvPairs = fieldValue.split(",");
     for (String fvPair : fvPairs) {
       String[] fieldAndValue = fvPair.split(":");
-      if (fieldAndValue.length != 2) {
+      if (fieldAndValue.length != 2 || fvPair.startsWith("$")) {
         continue;
       }
       String fieldName = fieldAndValue[0];
-      String fieldValue = fieldAndValue[1];
+      String fieldValue = fieldAndValue[1].contains("$") ? null : fieldAndValue[1];
       values.put(fieldName, fieldValue);
     }
     return values;
@@ -76,6 +79,13 @@ public class MultiFieldAdderConfig extends PluginConfig {
         values.put(fieldName, fieldValue);
       }
     }
+  }
+
+  /**
+   * Get fieldValue when either key or value specified as macro.
+   */
+  public String getMacroFieldValue() {
+    return getRawProperties().getProperties().get(FIELD_VALUE);
   }
 
   /**

--- a/src/test/java/io/cdap/plugin/add/field/MultiFieldAdderConfigTest.java
+++ b/src/test/java/io/cdap/plugin/add/field/MultiFieldAdderConfigTest.java
@@ -16,12 +16,14 @@
 
 package io.cdap.plugin.add.field;
 
+import io.cdap.cdap.api.macro.Macros;
+import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.FieldSetter;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * Unit tests for MultiFieldAdderConfig.
@@ -32,6 +34,24 @@ public class MultiFieldAdderConfigTest {
   private static final MultiFieldAdderConfig VALID_CONFIG = new MultiFieldAdderConfig(
     "test_1:s_value_1,test_2:s_value_2,test_3:s_value_3"
   );
+  private static final String ALL_KEYS_MACRO = "${test_1}:value_1,${test_2}:value_2,${test_3}:value_3";
+  private static final String NONE_KEY_MACRO = "test_1:${value_1},test_2:value_2,test_3:${value_3}";
+  private static final String NESTED_MACRO_KEY = "${test_1${nested_1}},value_1,${test_2${nested_2}}:value_2," +
+          "${test_3${nested_3}}:value_3";
+  private static final String NESTED_MACRO_VALUE = "test_1:${value_1${nested_1}},test_2:value_2," +
+          "test_3:${value_3${nested_3}}";
+  private static final String PARTIAL_MACRO_KEYS = "test_1:${value_1},test_2:value_2,test_3:${value_3}" +
+          ",${test_4}:value_4,${test_5}:value_5";
+  private static final String SECURE_MACRO = "test_1:${value_1},test_2:value_2,test_3:${value_3}," +
+          "${secure(test_4)}:${secure(value_4)}";
+  private static final String WHOLE_MACRO = "${value}";
+
+  private static final Map<String,String> MACRO_EXPECTED_VALUES = new HashMap<>();
+  static {
+    MACRO_EXPECTED_VALUES.put("test_1", null);
+    MACRO_EXPECTED_VALUES.put("test_2", "value_2");
+    MACRO_EXPECTED_VALUES.put("test_3", null);
+  }
 
   @Test
   public void testValidConfig() {
@@ -73,5 +93,106 @@ public class MultiFieldAdderConfigTest {
 
     config.validate(failureCollector);
     Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+  }
+
+  @Test
+  public void testAllKeysMacro() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(ALL_KEYS_MACRO);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(ALL_KEYS_MACRO, config.getMacroFieldValue());
+    Assert.assertTrue(config.getFieldValue().isEmpty());
+  }
+
+  @Test
+  public void testNoneKeysMacro() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(NONE_KEY_MACRO);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(NONE_KEY_MACRO, config.getMacroFieldValue());
+    Assert.assertEquals(MACRO_EXPECTED_VALUES, config.getFieldValue());
+  }
+
+  @Test
+  public void testNestedMacroKey() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(NESTED_MACRO_KEY);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(NESTED_MACRO_KEY, config.getMacroFieldValue());
+    Assert.assertTrue(config.getFieldValue().isEmpty());
+  }
+
+  @Test
+  public void testNestedMacroValue() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(NESTED_MACRO_VALUE);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(NESTED_MACRO_VALUE, config.getMacroFieldValue());
+    Assert.assertEquals(MACRO_EXPECTED_VALUES, config.getFieldValue());
+  }
+
+  @Test
+  public void testPartialMacroKeys() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(PARTIAL_MACRO_KEYS);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(PARTIAL_MACRO_KEYS, config.getMacroFieldValue());
+    Assert.assertEquals(MACRO_EXPECTED_VALUES, config.getFieldValue());
+  }
+
+  @Test
+  public void testSecureMacro() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(SECURE_MACRO);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(SECURE_MACRO, config.getMacroFieldValue());
+    Assert.assertEquals(MACRO_EXPECTED_VALUES, config.getFieldValue());
+  }
+
+  @Test
+  public void testWholeMacro() throws NoSuchFieldException {
+    MockFailureCollector failureCollector = new MockFailureCollector(MOCK_STAGE);
+    MultiFieldAdderConfig config = getMacroMultiFieldAdderConfig(WHOLE_MACRO);
+
+    config.validate(failureCollector);
+    Assert.assertTrue(failureCollector.getValidationFailures().isEmpty());
+    Assert.assertEquals(WHOLE_MACRO, config.getMacroFieldValue());
+    Assert.assertTrue(config.getFieldValue().isEmpty());
+  }
+
+  private static MultiFieldAdderConfig getMacroMultiFieldAdderConfig(String macro_value) throws NoSuchFieldException {
+    MultiFieldAdderConfig config = MultiFieldAdderConfig.builder().build();
+
+    Set<String> macroFields = new HashSet<>();
+    macroFields.add(MultiFieldAdderConfig.FIELD_VALUE);
+    Set<String> lookupProperties = new HashSet<>();
+    lookupProperties.add("value");
+    Map<String,String> properties = new HashMap<>();
+    properties.put(MultiFieldAdderConfig.FIELD_VALUE, macro_value);
+    Macros macros = new Macros(lookupProperties, null);
+
+    PluginProperties rawProperties = PluginProperties.builder()
+            .addAll(properties)
+            .build()
+            .setMacros(macros);
+
+    FieldSetter.setField(config, MultiFieldAdderConfig.class.getSuperclass().getDeclaredField("rawProperties"),
+            rawProperties);
+    FieldSetter.setField(config, MultiFieldAdderConfig.class.getSuperclass().getDeclaredField("macroFields"),
+            macroFields);
+
+    return config;
   }
 }


### PR DESCRIPTION
When you specify the values in multi-field adder as a macro, and the field names as a static string, add field into schema during configuration time.

JiraTicket: https://cdap.atlassian.net/browse/PLUGIN-488